### PR TITLE
Possibility of transferring user id

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,6 +636,14 @@ https://example.org/includinator/share.html?name=My+News&amp;link=http%3A%2F%2Fe
         being transmitted to a party that does not control the origin in
         question, or in clear text over the network.
         </li>
+        <li>A source site using Web Share API, and a receipient site using Web
+        Share Target, could cooperate to join user ids. The source site could
+        use `navigator.share(text: my_id_for_this_user)`, and the (user-chosen)
+        recipient could use that information to join its own user ID with the
+        source origin's user ID. Both sides of the transfer would need to write
+        code to accomplish the transfer, and the user would need to pick the
+        recipient.
+        </li>
       </ul>
     </section>
     <section id="conformance"></section>

--- a/level-2/index.html
+++ b/level-2/index.html
@@ -955,6 +955,14 @@ partial dictionary WebAppManifest {
           transmitted to a party that does not control the origin in question,
           or in clear text over the network.
         </li>
+        <li>A source site using Web Share API, and a receipient site using Web
+        Share Target, could cooperate to join user ids. The source site could
+        use `navigator.share(text: my_id_for_this_user)`, and the (user-chosen)
+        recipient could use that information to join its own user ID with the
+        source origin's user ID. Both sides of the transfer would need to write
+        code to accomplish the transfer, and the user would need to pick the
+        recipient.
+        </li>
       </ul>
     </section>
     <section class="appendix informative">


### PR DESCRIPTION
A site could navigator.share with a user id, and the (user-chosen)
recipient could use that information to join its own user ID with
the source origin's user ID.

resolves #99


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share-target/pull/100.html" title="Last updated on Feb 3, 2021, 3:24 AM UTC (b8772db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-share-target/100/a703396...ewilligers:b8772db.html" title="Last updated on Feb 3, 2021, 3:24 AM UTC (b8772db)">Diff</a>